### PR TITLE
fix(PPT-885): improves error handling

### DIFF
--- a/src/openslide-vendor-huron.c
+++ b/src/openslide-vendor-huron.c
@@ -276,6 +276,14 @@ static bool huron_detect(const char *filename G_GNUC_UNUSED,
       return true;
     }
   }
+
+  // err may be populated at this point if the TIFFTAG_MAKE was not found. 
+  // since we continue to search for other tags, we need to clear the error to 
+  // avoid overwriting it with a different error.
+  if (*err != NULL) {
+    g_clear_error(err);
+  }
+
   // check ImageSoftware
   tagval = _openslide_tifflike_get_buffer(tl, 0,
                                           TIFFTAG_SOFTWARE,
@@ -285,6 +293,14 @@ static bool huron_detect(const char *filename G_GNUC_UNUSED,
       return true;
     }
   }
+
+  // at this point neither tag we checked exists on the image
+  // so we clear the error one more time so we can set an indication
+  // that this is not a Huron slide.
+  if (*err != NULL) {
+    g_clear_error(err);
+  }
+
   // else
   g_set_error(err, OPENSLIDE_ERROR, OPENSLIDE_ERROR_FAILED,
               "Not a Huron slide");


### PR DESCRIPTION
When testing ingestion of another format I noticed the following showing up in the logs:

```
(vips:229904): GLib-WARNING **: 16:40:41.290: GError set over the top of a previous GError or uninitialized memory.
This indicates a bug in someone's code. You must ensure an error is NULL before it's set.
The overwriting error message was: Not a Huron slide
```

Because the Huron handler looks at a couple different tags now (for both Make and Software), it is possible that when looking up a tag we'll write to "err" because the tag is missing, but execution will continue (unlike Aperio handler where this was copied from - where they return false as soon as the tag is not found) - we then may write another error if the "software" tag is not found and then finally it will try to write a third error for "Not a Huron slide". So we need to clear out "err" as long as we continue to progress through the method. 