### PR TITLE
fix(PPT-922): handles errors in large svs images

### DIFF
--- a/src/openslide-vendor-aperio.c
+++ b/src/openslide-vendor-aperio.c
@@ -148,6 +148,17 @@ static bool decode_tile(struct level *l,
                                tile_col, tile_row, err);
   }
 
+  // read raw tile
+  void *buf;
+  int32_t buflen;
+  if (!_openslide_tiff_read_tile_data(tiffl, tiff,
+                                      &buf, &buflen,
+                                      tile_col, tile_row,
+                                      err)) {
+    return false;  // ok, haven't allocated anything yet
+  }
+  const unsigned char *bytes = buf;
+
   // select color space
   enum _openslide_jp2k_colorspace space;
   switch (l->compression) {
@@ -158,20 +169,14 @@ static bool decode_tile(struct level *l,
     space = OPENSLIDE_JP2K_RGB;
     break;
   default:
-    // not for us? fallback
-    return _openslide_tiff_read_tile(tiffl, tiff, dest,
-                                     tile_col, tile_row,
-                                     err);
-  }
-
-  // read raw tile
-  void *buf;
-  int32_t buflen;
-  if (!_openslide_tiff_read_tile_data(tiffl, tiff,
-                                      &buf, &buflen,
-                                      tile_col, tile_row,
-                                      err)) {
-    return false;  // ok, haven't allocated anything yet
+    // In large SVS Aperio images, a tile (typically 0, 0), in one or more levels, is partly overwritten.
+    // This also overrides the JPEG marker.
+    // Return false in order to fallback to a missing tile.
+    if (bytes[0] == 0x11 || (bytes[0] == 0xff && bytes[1] == 0x11)) {
+      return render_missing_tile(l, tiff, dest, tile_col, tile_row, err);
+    } else {
+      return _openslide_tiff_read_tile(tiffl, tiff, dest, tile_col, tile_row, err);
+    }
   }
 
   // decompress


### PR DESCRIPTION
While testing large SVS z-stack images (I have a 10GB file), it was noticed that after parsing the z-layers to individual svs per layer that when trying to convert certain layers to DZI we'd encounter:

`(vips:1365366): VIPS-WARNING **: 14:06:22.877: Unable to auto-correct subsampling values, likely corrupt JPEG compressed data in first strip/tile; auto-correcting skipped

(vips:1365366): VIPS-WARNING **: 14:06:22.877: error in tile 0 x 0

openslide2vips: reading region: Not a JPEG file: starts with 0x11 0x00`


Researching a bit and it seems like others have encountered this:
https://github.com/openslide/openslide/issues/225

In fact, our friends at Ibex implemented this fix in their repo, which is what I have copied in here:
https://github.com/ibex-ai/openslide/pull/2/files